### PR TITLE
Xcode 6.2 build fix

### DIFF
--- a/TextFieldValidationDemo/TextFieldValidationDemo/TextFieldValidationDemo-Prefix.pch
+++ b/TextFieldValidationDemo/TextFieldValidationDemo/TextFieldValidationDemo-Prefix.pch
@@ -1,0 +1,16 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#import <Availability.h>
+
+#ifndef __IPHONE_5_0
+#warning "This project uses features only available in iOS SDK 5.0 and later."
+#endif
+
+#ifdef __OBJC__
+    #import <UIKit/UIKit.h>
+    #import <Foundation/Foundation.h>
+#endif


### PR DESCRIPTION
Fix for xcode 6.0+ require pch file to be located in main project folder in order for project to build successfully
