### PR TITLE
delegate property changed from retain to weak

### DIFF
--- a/TextFieldValidator/TextFieldValidator.m
+++ b/TextFieldValidator/TextFieldValidator.m
@@ -85,7 +85,7 @@
 
 @interface TextFieldValidatorSupport : NSObject<UITextFieldDelegate>
 
-@property (nonatomic,retain) id<UITextFieldDelegate> delegate;
+@property (nonatomic,weak) id<UITextFieldDelegate> delegate;
 @property (nonatomic,assign) BOOL validateOnCharacterChanged;
 @property (nonatomic,assign) BOOL validateOnResign;
 @property (nonatomic,unsafe_unretained) IQPopUp *popUp;


### PR DESCRIPTION
The "<UITextFieldDelegate> delegate" property has been changed from retain to weak. It lets all the view controllers to be destroyed properly.

I noticed incorrect behaviour when I pop back from the view controller registered as the notifications observer, but its methods (specified by notificationSelector) were still called. 
